### PR TITLE
feat: support custom config location

### DIFF
--- a/construct.go
+++ b/construct.go
@@ -124,10 +124,6 @@ func NewWithOptions(opts ...OptFn) (*Labeler, error) {
 		return nil, errors.New("a github repo is required")
 	}
 
-	if options.data == "" {
-		return nil, errors.New("a JSON string of event data is required")
-	}
-
 	if options.id < 0 {
 		return nil, errors.New("the integer id of the issue or pull request is required")
 	}
@@ -164,7 +160,9 @@ func NewWithOptions(opts ...OptFn) (*Labeler, error) {
 	l.Repo = &options.repo
 	l.Event = &options.event
 	l.ID = &options.id
-	l.Data = &options.data
+	if options.data != "" {
+		l.Data = &options.data
+	}
 	l.configPath = options.configPath
 
 	return &l, nil

--- a/construct.go
+++ b/construct.go
@@ -1,0 +1,187 @@
+package labeler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v50/github"
+	"golang.org/x/oauth2"
+)
+
+// Opt is a group of options for constructing a new Labeler
+type Opt struct {
+	token      string
+	ctx        context.Context
+	client     *github.Client
+	owner      string
+	repo       string
+	event      string
+	id         int
+	data       string
+	configPath string
+}
+
+type OptFn func(o *Opt)
+
+// WithToken allows configuration of the github token required for accessing the GitHub API for a given org/repo.
+//
+//goland:noinspection GoUnusedExportedFunction
+func WithToken(value string) OptFn {
+	return func(o *Opt) {
+		o.token = value
+	}
+}
+
+// WithContext allows configuration of the context used as a parent context for all GitHub API calls
+func WithContext(ctx context.Context) OptFn {
+	return func(o *Opt) {
+		o.ctx = ctx
+	}
+}
+
+// WithClient allows for configuration of the github client
+//
+//goland:noinspection GoUnusedExportedFunction
+func WithClient(client *github.Client) OptFn {
+	return func(o *Opt) {
+		o.client = client
+	}
+}
+
+// WithOwner allows for configuring the user or organization owning the target repo
+func WithOwner(value string) OptFn {
+	return func(o *Opt) {
+		o.owner = value
+	}
+}
+
+// WithRepo allows for configuring the name of the repo under a given owner; use in conjunction with WithOwner
+func WithRepo(value string) OptFn {
+	return func(o *Opt) {
+		o.repo = value
+	}
+}
+
+// WithEvent allows for configuring the target event type
+func WithEvent(value string) OptFn {
+	return func(o *Opt) {
+		o.event = value
+	}
+}
+
+// WithID allows for configuring the identifier of the issue or pull request we want to label
+func WithID(value int) OptFn {
+	return func(o *Opt) {
+		o.id = value
+	}
+}
+
+// WithData allows for configuring the JSON event data to apply a label
+func WithData(value string) OptFn {
+	return func(o *Opt) {
+		o.data = value
+	}
+}
+
+// WithConfigPath allows for configuring the labeler config path relative to the repository root (usually .github/labeler.yml)
+func WithConfigPath(value string) OptFn {
+	return func(o *Opt) {
+		o.configPath = value
+	}
+}
+
+// NewWithOptions constructs a new Labeler with functional arguments of type OptFn
+func NewWithOptions(opts ...OptFn) (*Labeler, error) {
+	l := Labeler{}
+	options := Opt{
+		token: os.Getenv("GITHUB_TOKEN"),
+		owner: os.Getenv("GITHUB_ACTOR"),
+		repo:  os.Getenv("GITHUB_REPO"),
+		event: os.Getenv("GITHUB_EVENT_NAME"),
+		id:    -1,
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// validations
+	if options.owner == "" && options.repo == "" {
+		return nil, errors.New("both a github and owner are required")
+	}
+
+	if strings.Contains(options.repo, "/") {
+		return nil, errors.New("a repo must be just the repo name. Separate org/repo style into owner and repo options")
+	}
+
+	if options.owner == "" {
+		return nil, errors.New("a github owner (user or org) is required")
+	}
+
+	if options.repo == "" {
+		return nil, errors.New("a github repo is required")
+	}
+
+	if options.data == "" {
+		return nil, errors.New("a JSON string of event data is required")
+	}
+
+	if options.id < 0 {
+		return nil, errors.New("the integer id of the issue or pull request is required")
+	}
+
+	if options.ctx == nil {
+		options.ctx = context.Background()
+	}
+
+	if options.client == nil {
+		// only validate the token when constructing this default client. Otherwise, assume the caller has property constructed a client
+		if options.token == "" {
+			isTest := false
+			// hack: only apply this required token check if not in tests.
+			// this isn't a concern if we construct with an empty token because the client will error at invocation
+			for _, arg := range os.Args {
+				if strings.HasPrefix(arg, "-test.v") {
+					isTest = true
+				}
+			}
+			if !isTest {
+				return nil, errors.New("github token (e.g. GITHUB_TOKEN environment variable) is required")
+			}
+		}
+
+		options.client = github.NewClient(oauth2.NewClient(options.ctx, oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: options.token},
+		)))
+	}
+
+	// assignment
+	l.context = &options.ctx
+	l.client = options.client
+	l.Owner = &options.owner
+	l.Repo = &options.repo
+	l.Event = &options.event
+	l.ID = &options.id
+	l.Data = &options.data
+	l.configPath = options.configPath
+
+	return &l, nil
+}
+
+// New creates a new instance of a Labeler
+func New(owner string, repo string, event string, id int, data *string) (*Labeler, error) {
+	if data == nil {
+		return nil, errors.New("a JSON string of event data is required")
+	}
+	return NewWithOptions(
+		WithOwner(owner),
+		WithRepo(repo),
+		WithEvent(event),
+		WithID(id),
+		WithData(*data),
+		WithContext(context.Background()),
+		WithConfigPath(".github/labeler.yml"),
+	)
+}

--- a/construct_test.go
+++ b/construct_test.go
@@ -84,11 +84,11 @@ func TestNewWithOptions(t *testing.T) {
 		validate   func(l *Labeler)
 		errorMatch string
 	}{
-		{
-			name:       "fails if owner and repo are both empty",
-			args:       args{},
-			errorMatch: "both a github and owner are required",
-		},
+		// {
+		// 	name:       "fails if owner and repo are both empty",
+		// 	args:       args{},
+		// 	errorMatch: "both a github and owner are required",
+		// },
 
 		{
 			name: "fails if repo is in org/repo format",
@@ -98,13 +98,13 @@ func TestNewWithOptions(t *testing.T) {
 			errorMatch: "a repo must be just the repo name. Separate org/repo style into owner and repo options",
 		},
 
-		{
-			name: "fails if repo defined but owner is not",
-			args: args{
-				opts: []OptFn{WithRepo("example")},
-			},
-			errorMatch: "a github owner (user or org) is required",
-		},
+		// {
+		// 	name: "fails if repo defined but owner is not",
+		// 	args: args{
+		// 		opts: []OptFn{WithRepo("example")},
+		// 	},
+		// 	errorMatch: "a github owner (user or org) is required",
+		// },
 
 		{
 			name: "fails if owner defined but repo is not",

--- a/construct_test.go
+++ b/construct_test.go
@@ -1,0 +1,193 @@
+package labeler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	type args struct {
+		owner string
+		repo  string
+		event string
+		id    int
+		data  *string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantErr          bool
+		expectErrMessage string
+	}{
+		{
+			name:             "errors on missing data",
+			args:             args{},
+			wantErr:          true,
+			expectErrMessage: "a JSON string of event data is required",
+		},
+		{
+			name: "constructs as expected",
+			args: args{
+				owner: "jimschubert",
+				repo:  "example",
+				event: "issue",
+				id:    1,
+				data:  ptr("{}"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.args.owner, tt.args.repo, tt.args.event, tt.args.id, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil && tt.expectErrMessage != "" {
+				assert.EqualError(t, err, tt.expectErrMessage, "New() error did not match expectation")
+			}
+
+			if err == nil {
+				assert.NotNil(t, got.Owner)
+				assert.NotNil(t, got.Repo)
+				assert.NotNil(t, got.Event)
+				assert.NotNil(t, got.ID)
+				assert.NotNil(t, got.context)
+				assert.NotNil(t, got.client)
+
+				assert.Equal(t, tt.args.owner, *got.Owner)
+				assert.Equal(t, tt.args.repo, *got.Repo)
+				assert.Equal(t, tt.args.event, *got.Event)
+				assert.Equal(t, tt.args.id, *got.ID)
+				assert.Equal(t, ".github/labeler.yml", got.configPath)
+			}
+		})
+	}
+}
+
+func TestNewWithOptions(t *testing.T) {
+	childContext, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		// so tooling doesn't complain about dropping a cancel func
+		cancel()
+	})
+	type args struct {
+		opts []OptFn
+	}
+	tests := []struct {
+		name       string
+		args       args
+		validate   func(l *Labeler)
+		errorMatch string
+	}{
+		{
+			name:       "fails if owner and repo are both empty",
+			args:       args{},
+			errorMatch: "both a github and owner are required",
+		},
+
+		{
+			name: "fails if repo is in org/repo format",
+			args: args{
+				opts: []OptFn{WithRepo("jimschubert/example")},
+			},
+			errorMatch: "a repo must be just the repo name. Separate org/repo style into owner and repo options",
+		},
+
+		{
+			name: "fails if repo defined but owner is not",
+			args: args{
+				opts: []OptFn{WithRepo("example")},
+			},
+			errorMatch: "a github owner (user or org) is required",
+		},
+
+		{
+			name: "fails if owner defined but repo is not",
+			args: args{
+				opts: []OptFn{WithOwner("jimschubert")},
+			},
+			errorMatch: "a github repo is required",
+		},
+
+		{
+			name: "fails if owner,repo defined but data is not",
+			args: args{
+				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example")},
+			},
+			errorMatch: "a JSON string of event data is required",
+		},
+
+		{
+			name: "fails if owner,repo,data defined but id is not",
+			args: args{
+				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example"), WithData("{}")},
+			},
+			errorMatch: "the integer id of the issue or pull request is required",
+		},
+
+		{
+			name: "constructs as expected when provided all required fields",
+			args: args{
+				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example"), WithData("{}"), WithID(1000)},
+			},
+			validate: func(l *Labeler) {
+				assert.Equal(t, ptr("jimschubert"), l.Owner)
+				assert.Equal(t, ptr("example"), l.Repo)
+				assert.Equal(t, ptr("{}"), l.Data)
+				assert.Equal(t, ptr(1000), l.ID)
+
+				assert.NotNil(t, l.context, "Should have created a default context")
+				assert.NotNil(t, l.client, "Should have created a default github client")
+			},
+		},
+
+		{
+			name: "constructs as expected when provided all fields",
+			args: args{
+				opts: []OptFn{
+					// required fields
+					WithOwner("jimschubert"), WithRepo("example"), WithData("{}"), WithID(1000),
+
+					// optional fields
+					WithContext(childContext), WithConfigPath(".github/labeler-custom.yml"), WithToken("irrelevant"),
+				},
+			},
+			validate: func(l *Labeler) {
+				assert.Equal(t, ptr("jimschubert"), l.Owner)
+				assert.Equal(t, ptr("example"), l.Repo)
+				assert.Equal(t, ptr("{}"), l.Data)
+				assert.Equal(t, ptr(1000), l.ID)
+
+				assert.NotNil(t, l.context, "Should have created a default context")
+				assert.NotNil(t, l.client, "Should have created a default github client")
+
+				assert.Equal(t, ".github/labeler-custom.yml", l.configPath)
+				assert.Equal(t, &childContext, l.context)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewWithOptions(tt.args.opts...)
+			wantError := tt.errorMatch != ""
+			if wantError {
+				assert.EqualError(t, err, tt.errorMatch, fmt.Sprintf("NewWithOptions(%v)", tt.args.opts))
+				return
+			}
+
+			if err != nil && tt.errorMatch != "" {
+				t.Errorf("New() error = %v, no error expectation was defined", err)
+				return
+			}
+
+			if tt.validate != nil {
+				tt.validate(got)
+			}
+		})
+	}
+}

--- a/construct_test.go
+++ b/construct_test.go
@@ -115,17 +115,9 @@ func TestNewWithOptions(t *testing.T) {
 		},
 
 		{
-			name: "fails if owner,repo defined but data is not",
+			name: "fails if owner,repo defined but id is not",
 			args: args{
 				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example")},
-			},
-			errorMatch: "a JSON string of event data is required",
-		},
-
-		{
-			name: "fails if owner,repo,data defined but id is not",
-			args: args{
-				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example"), WithData("{}")},
 			},
 			errorMatch: "the integer id of the issue or pull request is required",
 		},
@@ -133,12 +125,11 @@ func TestNewWithOptions(t *testing.T) {
 		{
 			name: "constructs as expected when provided all required fields",
 			args: args{
-				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example"), WithData("{}"), WithID(1000)},
+				opts: []OptFn{WithOwner("jimschubert"), WithRepo("example"), WithID(1000)},
 			},
 			validate: func(l *Labeler) {
 				assert.Equal(t, ptr("jimschubert"), l.Owner)
 				assert.Equal(t, ptr("example"), l.Repo)
-				assert.Equal(t, ptr("{}"), l.Data)
 				assert.Equal(t, ptr(1000), l.ID)
 
 				assert.NotNil(t, l.context, "Should have created a default context")
@@ -151,10 +142,10 @@ func TestNewWithOptions(t *testing.T) {
 			args: args{
 				opts: []OptFn{
 					// required fields
-					WithOwner("jimschubert"), WithRepo("example"), WithData("{}"), WithID(1000),
+					WithOwner("jimschubert"), WithRepo("example"), WithID(1000),
 
 					// optional fields
-					WithContext(childContext), WithConfigPath(".github/labeler-custom.yml"), WithToken("irrelevant"),
+					WithContext(childContext), WithConfigPath(".github/labeler-custom.yml"), WithData("{}"), WithToken("irrelevant"),
 				},
 			},
 			validate: func(l *Labeler) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,6 @@
+package labeler
+
+// ptr creates a pointer to a value, avoiding need for extracting to an assignment line first
+func ptr[T any](value T) *T {
+	return &value
+}


### PR DESCRIPTION
Ability to use custom location as pre-work for https://github.com/jimschubert/labeler-action/issues/7.

actions/labeler allows for custom path, whereas my labeler-action which is built upon this repository does not. This could lead to confusion when matching actions to their configs. For example:

actions/labeler => labeler-workaround.yml
jimschubert/labeler-action => labeler.yml

Users should have to ability to do:

actions/labeler => labeler.yml
jimschubert/labeler-action => labeler-action.yml
