### PR TITLE
feat: allow user to choose title and/or description for evaluation

### DIFF
--- a/cmd/labeler/root.go
+++ b/cmd/labeler/root.go
@@ -29,6 +29,7 @@ func newRootCmd() *cobra.Command {
 		ID         int
 		Data       string
 		ConfigPath string
+		Fields     []string
 	}
 	o := options{
 		Owner: os.Getenv("GITHUB_ACTOR"),
@@ -53,6 +54,11 @@ func newRootCmd() *cobra.Command {
 			if o.ConfigPath != "" {
 				labelOpts = append(labelOpts, labeler.WithConfigPath(o.ConfigPath))
 			}
+			if len(o.Fields) > 0 {
+				fieldFlags := labeler.ParseFieldFlags(o.Fields)
+				labelOpts = append(labelOpts, labeler.WithFields(fieldFlags))
+			}
+
 			l, err := labeler.NewWithOptions(labelOpts...)
 			if err != nil {
 				return fmt.Errorf("could not initialize labeler: %w", err)
@@ -68,6 +74,7 @@ func newRootCmd() *cobra.Command {
 	c.Flags().StringVarP(&o.Owner, "owner", "o", o.Owner, "GitHub Owner/Org name [GITHUB_ACTOR]")
 	c.Flags().StringVarP(&o.Repo, "repo", "r", o.Repo, "GitHub Repo name [GITHUB_REPO]")
 	c.Flags().StringVarP(&o.Type, "type", "t", o.Type, "The target event type to label (issues or pull_request) [GITHUB_EVENT_NAME]")
+	c.Flags().StringSliceVar(&o.Fields, "fields", []string{"title", "body"}, "Fields to evaluate for labeling (title, body)")
 	c.Flags().IntVarP(&o.ID, "id", "", o.ID, "The integer id of the issue or pull request")
 	c.Flags().StringVarP(&o.Data, "data", "", o.Data, "A JSON string of the 'event' type (issue event or pull request event)")
 	c.Flags().StringVarP(&o.ConfigPath, "config-path", "", o.ConfigPath, "A custom config path, relative to the repository root")

--- a/construct.go
+++ b/construct.go
@@ -24,6 +24,7 @@ type Opt struct {
 	id         int
 	data       string
 	configPath string
+	fieldFlags FieldFlag
 }
 
 type OptFn func(o *Opt)
@@ -95,15 +96,23 @@ func WithConfigPath(value string) OptFn {
 	}
 }
 
+// WithFields allows for configuring the fields to evaluate for labeling
+func WithFields(fieldFlag FieldFlag) OptFn {
+	return func(o *Opt) {
+		o.fieldFlags = fieldFlag.OrDefault()
+	}
+}
+
 // NewWithOptions constructs a new Labeler with functional arguments of type OptFn
 func NewWithOptions(opts ...OptFn) (*Labeler, error) {
 	l := Labeler{}
 	options := Opt{
-		token: os.Getenv("GITHUB_TOKEN"),
-		owner: os.Getenv("GITHUB_ACTOR"),
-		repo:  os.Getenv("GITHUB_REPO"),
-		event: os.Getenv("GITHUB_EVENT_NAME"),
-		id:    -1,
+		token:      os.Getenv("GITHUB_TOKEN"),
+		owner:      os.Getenv("GITHUB_ACTOR"),
+		repo:       os.Getenv("GITHUB_REPO"),
+		event:      os.Getenv("GITHUB_EVENT_NAME"),
+		id:         -1,
+		fieldFlags: AllFieldFlags,
 	}
 
 	for _, opt := range opts {
@@ -157,6 +166,7 @@ func NewWithOptions(opts ...OptFn) (*Labeler, error) {
 	l.Repo = &options.repo
 	l.Event = &options.event
 	l.ID = &options.id
+	l.fieldFlag = options.fieldFlags
 	if options.data != "" {
 		l.Data = &options.data
 	}

--- a/construct_test.go
+++ b/construct_test.go
@@ -68,6 +68,7 @@ func TestNew(t *testing.T) {
 				assert.Equal(t, tt.args.repo, *got.Repo)
 				assert.Equal(t, tt.args.event, *got.Event)
 				assert.Equal(t, tt.args.id, *got.ID)
+				assert.Equal(t, AllFieldFlags, got.fieldFlag)
 				assert.Equal(t, ".github/labeler.yml", got.configPath)
 			}
 		})
@@ -141,6 +142,7 @@ func TestNewWithOptions(t *testing.T) {
 				assert.Equal(t, ptr("jimschubert"), l.Owner)
 				assert.Equal(t, ptr("example"), l.Repo)
 				assert.Equal(t, ptr(1000), l.ID)
+				assert.Equal(t, AllFieldFlags, l.fieldFlag)
 
 				assert.NotNil(t, l.context, "Should have created a default context")
 				assert.NotNil(t, l.client, "Should have created a default github client")
@@ -155,7 +157,7 @@ func TestNewWithOptions(t *testing.T) {
 					WithOwner("jimschubert"), WithRepo("example"), WithID(1000),
 
 					// optional fields
-					WithContext(childContext), WithConfigPath(".github/labeler-custom.yml"), WithData("{}"), WithToken("irrelevant"),
+					WithContext(childContext), WithConfigPath(".github/labeler-custom.yml"), WithData("{}"), WithToken("irrelevant"), WithFields(AllFieldFlags),
 				},
 			},
 			validate: func(l *Labeler) {
@@ -163,6 +165,7 @@ func TestNewWithOptions(t *testing.T) {
 				assert.Equal(t, ptr("example"), l.Repo)
 				assert.Equal(t, ptr("{}"), l.Data)
 				assert.Equal(t, ptr(1000), l.ID)
+				assert.Equal(t, AllFieldFlags, l.fieldFlag)
 
 				assert.NotNil(t, l.context, "Should have created a default context")
 				assert.NotNil(t, l.client, "Should have created a default github client")

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package labeler provides a utility for labeling GitHub issues and pull requests based on configurable rules and field evaluation.
+package labeler

--- a/fields.go
+++ b/fields.go
@@ -1,0 +1,43 @@
+package labeler
+
+// FieldFlag represents a bitmask for fields that can be evaluated for labeling.
+// Use bitwise operations or helper methods to combine and check flags.
+type FieldFlag uint
+
+// Has returns true if the FieldFlag contains the provided flag.
+func (f FieldFlag) Has(flag FieldFlag) bool {
+	return f&flag != 0
+}
+
+// OrDefault returns AllFieldFlags if no flags are set (f == 0), otherwise returns f.
+func (f FieldFlag) OrDefault() FieldFlag {
+	if f == 0 {
+		return AllFieldFlags
+	}
+	return f
+}
+
+const (
+	// FieldTitle indicates the title field should be evaluated for labeling.
+	FieldTitle FieldFlag = 1 << iota
+	// FieldBody indicates the body field should be evaluated for labeling.
+	FieldBody
+
+	// AllFieldFlags is a convenience constant representing all available fields.
+	AllFieldFlags = FieldTitle | FieldBody
+)
+
+// ParseFieldFlags converts a slice of string field names to a FieldFlag bitmask.
+// Unrecognized field names are ignored.
+func ParseFieldFlags(fields []string) FieldFlag {
+	var flags FieldFlag
+	for _, f := range fields {
+		switch f {
+		case "title":
+			flags |= FieldTitle
+		case "body":
+			flags |= FieldBody
+		}
+	}
+	return flags
+}

--- a/fields_test.go
+++ b/fields_test.go
@@ -1,0 +1,84 @@
+package labeler
+
+import (
+	"testing"
+)
+
+func TestFieldFlag_Has(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     FieldFlag
+		check    FieldFlag
+		expected bool
+	}{
+		{"Has title", FieldTitle, FieldTitle, true},
+		{"Has body", FieldBody, FieldBody, true},
+		{"Has both", AllFieldFlags, FieldTitle, true},
+		{"Has both (body)", AllFieldFlags, FieldBody, true},
+		{"Does not have", FieldTitle, FieldBody, false},
+		{"Zero flag", 0, FieldTitle, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.flag.Has(tt.check)
+			if got != tt.expected {
+				t.Errorf("FieldFlag(%d).Has(%d) = %v; want %v", tt.flag, tt.check, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFieldFlag_OrDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     FieldFlag
+		expected FieldFlag
+	}{
+		{"Non-zero returns self", FieldTitle, FieldTitle},
+		{"AllFieldFlags returns self", AllFieldFlags, AllFieldFlags},
+		{"Zero returns AllFieldFlags", 0, AllFieldFlags},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.flag.OrDefault()
+			if got != tt.expected {
+				t.Errorf("FieldFlag(%d).OrDefault() = %d; want %d", tt.flag, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseFieldFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected FieldFlag
+	}{
+		{"Empty slice", []string{}, 0},
+		{"Single title", []string{"title"}, FieldTitle},
+		{"Single body", []string{"body"}, FieldBody},
+		{"Both fields", []string{"title", "body"}, AllFieldFlags},
+		{"Duplicate fields", []string{"title", "title"}, FieldTitle},
+		{"Unknown field", []string{"unknown"}, 0},
+		{"Mixed known and unknown", []string{"title", "unknown"}, FieldTitle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseFieldFlags(tt.input)
+			if got != tt.expected {
+				t.Errorf("ParseFieldFlags(%v) = %d; want %d", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAllFieldFlagsValue(t *testing.T) {
+	expected := FieldTitle | FieldBody
+	// Ensure AllFieldFlags is set to the correct value of OR'd flags.
+	if AllFieldFlags != expected {
+		t.Errorf("AllFieldFlags = %d; want %d", AllFieldFlags, expected)
+	}
+}

--- a/labeler.go
+++ b/labeler.go
@@ -37,6 +37,7 @@ type Labeler struct {
 	client     model.Client
 	config     model.Config
 	configPath string
+	fieldFlag  FieldFlag
 }
 
 // Execute performs the labeler logic
@@ -201,7 +202,18 @@ func (l *Labeler) applyLabels(i githubEvent, existingLabels []*github.Label) int
 		targetBranch = *pr.Base.Ref
 	}
 
-	labels := l.config.LabelsFor(i.GetTitle(), i.GetBody())
+	flags := l.fieldFlag.OrDefault()
+	fields := make([]string, 0)
+
+	if flags.Has(FieldTitle) {
+		fields = append(fields, i.GetTitle())
+	}
+
+	if flags.Has(FieldBody) {
+		fields = append(fields, i.GetBody())
+	}
+
+	labels := l.config.LabelsFor(fields...)
 	filteredLabels := make(map[string]model.Label)
 	for name, label := range labels {
 		if len(label.Branches) > 0 && targetBranch != "" {


### PR DESCRIPTION
Users can now choose between title and description (or both) as the targets for rules evaluation. This will help, for example, if you're using issues for triage and certain user comments from external contributors can apply a label to your repo. It also allows to avoid unexpected words in the PR or Issue description from adding unwanted labels.